### PR TITLE
risktravel-dashboard-v3

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -28,11 +28,10 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       <header className="app-header">
         <h1>RiskTravel</h1>
         <nav className="app-nav">
-          {/* These links are placeholders. As you build out more pages
-              (e.g. /agents, /metrics, /crm), update the hrefs accordingly. */}
           <a href="/">Home</a>
-          <a href="#agents">Agents</a>
-          <a href="#metrics">Metrics</a>
+          <a href="/agents">Agents</a>
+          <a href="/metrics">Metrics</a>
+          <a href="/crm">CRM</a>
         </nav>
       </header>
       <Component {...pageProps} />

--- a/src/pages/agents.tsx
+++ b/src/pages/agents.tsx
@@ -1,0 +1,66 @@
+import Head from 'next/head';
+
+/**
+ * Agents page
+ *
+ * This page provides a placeholder for monitoring the status of your
+ * automation agents. In a full implementation this would fetch live
+ * agent data from your database or API and display it in a table or
+ * dashboard. For now, we include static content to illustrate the
+ * structure and styling.
+ */
+export default function Agents() {
+  return (
+    <>
+      <Head>
+        <title>Agents · RiskTravel Dashboard</title>
+      </Head>
+      <main className="container">
+        <h1>Automation Agents</h1>
+        <p>
+          Monitor the status, last run time and success rate of your
+          automation agents here. As you build out your agent fleet,
+          populate this table with data from your Airtable base or
+          database.
+        </p>
+        <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '1rem' }}>
+          <thead>
+            <tr style={{ backgroundColor: 'var(--colour-mid-purple)', color: 'white' }}>
+              <th style={{ padding: '0.5rem', textAlign: 'left' }}>Agent Name</th>
+              <th style={{ padding: '0.5rem', textAlign: 'left' }}>Description</th>
+              <th style={{ padding: '0.5rem', textAlign: 'left' }}>Status</th>
+              <th style={{ padding: '0.5rem', textAlign: 'left' }}>Last Run</th>
+            </tr>
+          </thead>
+          <tbody>
+            {/* Static example rows; replace with dynamic content later */}
+            <tr style={{ backgroundColor: '#f5f5fa' }}>
+              <td style={{ padding: '0.5rem' }}>Outreach Agent</td>
+              <td style={{ padding: '0.5rem' }}>Generates and sends tailored outreach messages</td>
+              <td style={{ padding: '0.5rem' }}>Idle</td>
+              <td style={{ padding: '0.5rem' }}>–</td>
+            </tr>
+            <tr>
+              <td style={{ padding: '0.5rem' }}>Content Repurposer</td>
+              <td style={{ padding: '0.5rem' }}>Creates social media posts and blog drafts</td>
+              <td style={{ padding: '0.5rem' }}>Running</td>
+              <td style={{ padding: '0.5rem' }}>Aug 19, 2025 10:15am</td>
+            </tr>
+            <tr style={{ backgroundColor: '#f5f5fa' }}>
+              <td style={{ padding: '0.5rem' }}>Booking/CRM</td>
+              <td style={{ padding: '0.5rem' }}>Synchronises Calendly bookings to your CRM</td>
+              <td style={{ padding: '0.5rem' }}>Idle</td>
+              <td style={{ padding: '0.5rem' }}>–</td>
+            </tr>
+            <tr>
+              <td style={{ padding: '0.5rem' }}>Analytics</td>
+              <td style={{ padding: '0.5rem' }}>Tracks metrics and generates weekly reports</td>
+              <td style={{ padding: '0.5rem' }}>Paused</td>
+              <td style={{ padding: '0.5rem' }}>Aug 18, 2025 9:00am</td>
+            </tr>
+          </tbody>
+        </table>
+      </main>
+    </>
+  );
+}

--- a/src/pages/crm.tsx
+++ b/src/pages/crm.tsx
@@ -1,0 +1,62 @@
+import Head from 'next/head';
+
+/**
+ * CRM page
+ *
+ * A placeholder for managing contacts, leads, and clients. In a
+ * production dashboard, this would be connected to your Airtable or
+ * database. Here we display a static table to illustrate the layout.
+ */
+export default function CRM() {
+  return (
+    <>
+      <Head>
+        <title>CRM · RiskTravel Dashboard</title>
+      </Head>
+      <main className="container">
+        <h1>Customer Relationship Manager</h1>
+        <p>
+          Keep track of your leads, prospects and clients. This table is a
+          placeholder; connect it to Airtable or another CRM to populate it
+          with real data.
+        </p>
+        <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '1rem' }}>
+          <thead>
+            <tr style={{ backgroundColor: 'var(--colour-grey-blue)', color: 'white' }}>
+              <th style={{ padding: '0.5rem', textAlign: 'left' }}>Name</th>
+              <th style={{ padding: '0.5rem', textAlign: 'left' }}>Email</th>
+              <th style={{ padding: '0.5rem', textAlign: 'left' }}>Persona</th>
+              <th style={{ padding: '0.5rem', textAlign: 'left' }}>Stage</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr style={{ backgroundColor: '#f5f5fa' }}>
+              <td style={{ padding: '0.5rem' }}>Jane Merrick</td>
+              <td style={{ padding: '0.5rem' }}>jane@example.com</td>
+              <td style={{ padding: '0.5rem' }}>Merrick</td>
+              <td style={{ padding: '0.5rem' }}>Initial Contact</td>
+            </tr>
+            <tr>
+              <td style={{ padding: '0.5rem' }}>Kelly Lee</td>
+              <td style={{ padding: '0.5rem' }}>kelly@example.com</td>
+              <td style={{ padding: '0.5rem' }}>Kelly</td>
+              <td style={{ padding: '0.5rem' }}>Engaged</td>
+            </tr>
+            <tr style={{ backgroundColor: '#f5f5fa' }}>
+              <td style={{ padding: '0.5rem' }}>Javi Gomez</td>
+              <td style={{ padding: '0.5rem' }}>javi@example.com</td>
+              <td style={{ padding: '0.5rem' }}>Javi</td>
+              <td style={{ padding: '0.5rem' }}>Booked Call</td>
+            </tr>
+            <tr>
+              <td style={{ padding: '0.5rem' }}>Alex Johnson</td>
+              <td style={{ padding: '0.5rem' }}>alex@example.com</td>
+              <td style={{ padding: '0.5rem' }}>Whispering Pines Lead</td>
+              <td style={{ padding: '0.5rem' }}>Deposit Paid</td>
+            </tr>
+          </tbody>
+        </table>
+      </main>
+    </>
+  );
+}

--- a/src/pages/metrics.tsx
+++ b/src/pages/metrics.tsx
@@ -1,0 +1,89 @@
+import Head from 'next/head';
+
+/**
+ * Metrics page
+ *
+ * This page provides a placeholder for displaying high‑level KPIs and
+ * metrics about your business. In a real implementation, these values
+ * would be pulled from your database or analytics service. Here we
+ * simply render static cards styled with your brand palette.
+ */
+export default function Metrics() {
+  return (
+    <>
+      <Head>
+        <title>Metrics · RiskTravel Dashboard</title>
+      </Head>
+      <main className="container">
+        <h1>Key Metrics</h1>
+        <p>
+          These cards will soon reflect live data from your AI governance
+          and retreat business. Use this page to track revenue, leads,
+          engagement and other important KPIs.
+        </p>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+            gap: '1rem',
+            marginTop: '1rem',
+          }}
+        >
+          {/* Example metric card */}
+          <div
+            style={{
+              background: 'var(--colour-deep-purple)',
+              color: 'white',
+              padding: '1.5rem',
+              borderRadius: '0.5rem',
+              boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+            }}
+          >
+            <h3 style={{ marginTop: 0 }}>Monthly Revenue</h3>
+            <p style={{ fontSize: '1.75rem', fontWeight: 600 }}>$0</p>
+            <small style={{ opacity: 0.8 }}>Target: $50K</small>
+          </div>
+          <div
+            style={{
+              background: 'var(--colour-mid-purple)',
+              color: 'white',
+              padding: '1.5rem',
+              borderRadius: '0.5rem',
+              boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+            }}
+          >
+            <h3 style={{ marginTop: 0 }}>Open Leads</h3>
+            <p style={{ fontSize: '1.75rem', fontWeight: 600 }}>0</p>
+            <small style={{ opacity: 0.8 }}>Target: 25</small>
+          </div>
+          <div
+            style={{
+              background: 'var(--colour-aubergine)',
+              color: 'white',
+              padding: '1.5rem',
+              borderRadius: '0.5rem',
+              boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+            }}
+          >
+            <h3 style={{ marginTop: 0 }}>Retreat Deposits</h3>
+            <p style={{ fontSize: '1.75rem', fontWeight: 600 }}>0</p>
+            <small style={{ opacity: 0.8 }}>Target: 8 guests</small>
+          </div>
+          <div
+            style={{
+              background: 'var(--colour-dark-cyan)',
+              color: 'white',
+              padding: '1.5rem',
+              borderRadius: '0.5rem',
+              boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+            }}
+          >
+            <h3 style={{ marginTop: 0 }}>Video Views</h3>
+            <p style={{ fontSize: '1.75rem', fontWeight: 600 }}>0</p>
+            <small style={{ opacity: 0.8 }}>Goal: 10K</small>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
Added Agents, Metrics, and CRM pages (with navigation links) so you can view placeholders for agent status, key KPIs, and a contact list.

Built simple metric cards and tables styled using your brand palette and fonts.

Updated the header to link to the new pages.

Kept the global colour variables and font imports so the entire app reflects your Incluu branding.